### PR TITLE
Rebornix

### DIFF
--- a/public/app/services/storyService.js
+++ b/public/app/services/storyService.js
@@ -1,7 +1,7 @@
 angular.module('storyService', [])
 
 
-.factory('Story', function($http) {
+.factory('Story', function($http, $window) {
 
 	// get all approach
 	var storyFactory = {};

--- a/public/app/services/storyService.js
+++ b/public/app/services/storyService.js
@@ -5,19 +5,32 @@ angular.module('storyService', [])
 
 	// get all approach
 	var storyFactory = {};
+	
+	var generateReq = function(method, url, data) {
+            var req = {
+              method: method,
+              url: url,
+              headers: {
+                'x-access-token': $window.localStorage.getItem('token')
+              };
+            if (method === 'POST') {
+            	req.data = data;
+            }
+            return req;
+        };
 
 	storyFactory.all = function() {
-		return $http.get('/api/');
-	}
+		return $http(generateReq('GET', '/api/'));
+	};
 
 
 	storyFactory.create = function(storyData) {
-		return $http.post('/api/', storyData);
-	}
+		return $http(generateReq('POST', '/api/', storyData));
+	};
 
 	storyFactory.getSingleStory = function(user_name, story_id) {
-		return $http.get('/api/' + user_name + story_id);
-	}
+		return $http(generateReq('GET', '/api/' + user_name + story_id));
+	};
 
 	return storyFactory;
 

--- a/public/app/services/userService.js
+++ b/public/app/services/userService.js
@@ -19,11 +19,7 @@ angular.module('userService', [])
     var req = {
         method: 'POST',
         url: '/api/signup',
-                    data: userData,
-        headers: {
-            'x-access-token': $window.localStorage.getItem('token')
-        }
-
+        data: userData
     }
     return $http(req);
 }

--- a/public/app/services/userService.js
+++ b/public/app/services/userService.js
@@ -16,13 +16,8 @@ angular.module('userService', [])
 
 
 	userFactory.create = function(userData) {
-    var req = {
-        method: 'POST',
-        url: '/api/signup',
-        data: userData
-    }
-    return $http(req);
-}
+          return $http.post('/api/signup', userData);
+        }
 
 
 	userFactory.update = function(id, userData) {


### PR DESCRIPTION
When users attempt to sign up, there is no token in localStorage, so we shouldn't add any Authentication headers in request. 

After users login, they would call `story` related APIs to fetch his/her own stories. These API should require Authentication Validation. So we wrap all requests with token.
